### PR TITLE
Separer api-kall fra applikasjonslogikk

### DIFF
--- a/src/core/api/ApiUtils.ts
+++ b/src/core/api/ApiUtils.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line no-undef
+export function api<T>(input: RequestInfo, init?: RequestInit | undefined): Promise<T> {
+  const uri = `/api${input}`;
+  return fetch(uri, init)
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
+      return response.json() as Promise<{ data: T }>;
+    })
+    .then(data => {
+      return data.data;
+    });
+}

--- a/src/core/api/ApiUtils.ts
+++ b/src/core/api/ApiUtils.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-undef
 export function api<T>(input: RequestInfo, init?: RequestInit | undefined): Promise<T> {
-  const uri = `/api${input}`;
+  const uri = `${process.env.REACT_APP_BACKEND_API_ROOT}/api${input}`;
   return fetch(uri, init)
     .then(response => {
       if (!response.ok) {

--- a/src/core/api/ApiUtils.ts
+++ b/src/core/api/ApiUtils.ts
@@ -1,7 +1,11 @@
 // eslint-disable-next-line no-undef
 export function api<T>(input: RequestInfo, init?: RequestInit | undefined): Promise<T> {
   const uri = `${process.env.REACT_APP_BACKEND_API_ROOT}/api${input}`;
-  return fetch(uri, init)
+  const rInit = { ...init };
+  rInit.headers = {
+    'Content-Type': 'application/json',
+  };
+  return fetch(uri, rInit)
     .then(response => {
       if (!response.ok) {
         throw new Error(response.statusText);

--- a/src/core/api/QueryKeys.ts
+++ b/src/core/api/QueryKeys.ts
@@ -1,0 +1,3 @@
+export const enum QueryKeys {
+  Tiltakstyper,
+}

--- a/src/core/api/TiltakstypeService.ts
+++ b/src/core/api/TiltakstypeService.ts
@@ -1,0 +1,21 @@
+import { Tiltakstype } from '../domain/Tiltakstype';
+import { api } from './ApiUtils';
+
+const getAllTiltakstyper = () => api<Tiltakstype[]>('/tiltakstyper', { method: 'GET' });
+
+const getTiltakstypeById = (id: number) => api<Tiltakstype>(`/tiltakstyper/${id}`, { method: 'GET' });
+
+const postTiltakstype = (tiltakstype: Tiltakstype) =>
+  api<Tiltakstype>('/tiltakstyper', { method: 'POST', body: JSON.stringify(tiltakstype) });
+
+const putTiltakstype = (tiltakstype: Tiltakstype) =>
+  api<Tiltakstype>(`/tiltakstyper/${tiltakstype.id}`, { method: 'PUT', body: JSON.stringify(tiltakstype) });
+
+const TiltakstypeService = {
+  getAllTiltakstyper,
+  getTiltakstypeById,
+  postTiltakstype,
+  putTiltakstype,
+};
+
+export default TiltakstypeService;


### PR DESCRIPTION
**PS: Må merges etter de andre.**

Nå har vi en veldig rotete struktur hvor noen av fetch-kallene gjøres inline i komponentene og noen har blitt lagt på siden i separate filer. Det å holde fetch-kallene så simple som mulig gjør at vi slipper masse side-effects som er et helvete å debugge når applikasjonen vokser.

La også til et enum `QueryKeys` som skal brukes sammen med `react-query`.

Bruk av denne servicen f.eks:
```
const { isLoading, isSuccess, data, isError } = useQuery(QueryKeys.Tiltakstyper, TiltakstypeService.getAllTiltakstyper)
```
