### PR TITLE
Implementer en felles Link-komponent

### DIFF
--- a/src/components/link/Link.less
+++ b/src/components/link/Link.less
@@ -1,0 +1,8 @@
+.link {
+  text-decoration: none;
+  &:hover,
+  &:focus,
+  &:active {
+    text-decoration: none;
+  }
+}

--- a/src/components/link/Link.tsx
+++ b/src/components/link/Link.tsx
@@ -1,13 +1,27 @@
 import React from 'react';
+import cn from 'classnames';
+import './Link.less';
+import 'nav-frontend-lenker-style';
+import Lenke from 'nav-frontend-lenker';
 import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
 
-interface LinkProps extends RouterLinkProps, React.HTMLAttributes<HTMLAnchorElement> {
+interface LinkProps extends RouterLinkProps {
+  isInline?: boolean;
+  isExternal?: boolean;
   children?: React.ReactNode;
 }
 
 function Link(props: LinkProps) {
-  const { children, ...others } = props;
-  return <RouterLink {...others}>{children}</RouterLink>;
+  const { children, isExternal = false, isInline = false, to, className, ...others } = props;
+  return isExternal ? (
+    <Lenke href={to.toString()} className={className} {...others}>
+      {children}
+    </Lenke>
+  ) : (
+    <RouterLink to={to} className={cn('link', { lenke: isInline }, className)} {...others}>
+      {children}
+    </RouterLink>
+  );
 }
 
 export default Link;

--- a/src/components/tiltaksoversikt/listevisning/TiltakRad.tsx
+++ b/src/components/tiltaksoversikt/listevisning/TiltakRad.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Tiltakstype } from '../../../core/domain/Tiltakstype';
-import { Link } from 'react-router-dom';
+import Link from '../../link/Link';
 import './TiltakListevisning.less';
 
 interface TiltakRadProps {
@@ -13,7 +13,7 @@ const TiltakRad = ({ tiltak }: TiltakRadProps) => {
     <tr key={id}>
       <td>{id}</td>
       <td>
-        <Link to={`/tiltakstype/${id}`} className="tabell__link">
+        <Link to={`/tiltakstype/${id}`} isInline>
           {tittel}
         </Link>
       </td>

--- a/src/layouts/MainView.tsx
+++ b/src/layouts/MainView.tsx
@@ -1,9 +1,9 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
 import { Container, Row } from 'react-bootstrap';
 import { Tilbakeknapp } from 'nav-frontend-ikonknapper';
 import './MainView.less';
 import { Sidetittel, Systemtittel } from 'nav-frontend-typografi';
+import Link from '../components/link/Link';
 
 interface MainViewProps {
   showBackButton?: boolean;

--- a/src/views/tiltakstype-detaljer/Tiltaksvisning.tsx
+++ b/src/views/tiltakstype-detaljer/Tiltaksvisning.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import './Tiltaksvisning.less';
 import { Innholdstittel } from 'nav-frontend-typografi';
 import { useQuery } from 'react-query';
@@ -9,6 +9,7 @@ import { Hovedknapp } from 'nav-frontend-knapper';
 import { QueryKeys } from '../../core/api/QueryKeys';
 import TiltakstypeService from '../../core/api/TiltakstypeService';
 import MainView from '../../layouts/MainView';
+import Link from '../../components/link/Link';
 
 interface routeParams {
   id: string;
@@ -36,8 +37,8 @@ const Tiltaksvisning = () => {
 
         <p className="tiltaksvisning__beskrivelse">{data?.beskrivelse}</p>
 
-        <Link to={`/admin/rediger-tiltakstype/${id}`}>
-          <Hovedknapp>Rediger tiltak</Hovedknapp>
+        <Link to={`/admin/rediger-tiltakstype/${id}`} className="knapp knapp--hoved">
+          Rediger
         </Link>
       </div>
     </MainView>

--- a/src/views/tiltakstype-detaljer/Tiltaksvisning.tsx
+++ b/src/views/tiltakstype-detaljer/Tiltaksvisning.tsx
@@ -5,7 +5,6 @@ import { Innholdstittel } from 'nav-frontend-typografi';
 import { useQuery } from 'react-query';
 import NavFrontendSpinner from 'nav-frontend-spinner';
 import AlertStripe from 'nav-frontend-alertstriper';
-import { Hovedknapp } from 'nav-frontend-knapper';
 import { QueryKeys } from '../../core/api/QueryKeys';
 import TiltakstypeService from '../../core/api/TiltakstypeService';
 import MainView from '../../layouts/MainView';


### PR DESCRIPTION
Opprettet en felles `<Link>`-komponent som tar i bruk både `<Lenke>` fra `nav-frontend-moduler` og internt fra `react-router-dom`. Den har noen kjøreregler som alle andre lenker i React. Intern navigering skal skje via `react-router` slik at applikasjonen beholder context og state, uten det får vi mye rar oppførsel.

**Scenario 1** - Vi vil wrappe en knapp-komponent med en navigering som ikke tvinger på seg noe styling:
```
<Link to="/et-eller-annet-internt" className="knapp knapp--hoved">Gå til noe internt</Link>
```

**Scenario 2** - Vi vil navigere internt, men ha samme inline-styling som lenker fra `nav-frontend-moduler`. Brukes ofte inne i tekst osv:
```
<Link to="/et-eller-annet-internt" isInline>Gå til noe internt</Link>
```

**Scenario 3** - Vi vil sende bruker eller lenke til noe ekstern utenfor vår applikasjon:
```
<Link to="https://www.skattedirektoratet.no" isExternal>Gå til Skattedirektoratets hjemmeside</Link>
```