### PR TITLE
La til ellipsis på kolonnene i tiltakstypeoversikten

### DIFF
--- a/src/components/tiltakstypeoversikt/listevisning/TiltakstypeRad.less
+++ b/src/components/tiltakstypeoversikt/listevisning/TiltakstypeRad.less
@@ -1,14 +1,23 @@
 .tabell {
-  &__row{
+  &__row {
     position: relative;
     a::after {
-      content: "";
+      content: '';
       display: block;
       position: absolute;
       top: 0;
       bottom: 0;
       left: 0;
       right: 0;
+    }
+    &__ingress {
+      width: 70%; // Midlertidig for at ikke ting blir 50/50 på to kolonner
+    }
+    td {
+      max-width: 100px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   }
 }

--- a/src/components/tiltakstypeoversikt/listevisning/TiltakstypeRad.tsx
+++ b/src/components/tiltakstypeoversikt/listevisning/TiltakstypeRad.tsx
@@ -9,7 +9,6 @@ interface TiltakstypeRadProps {
 
 const TiltakstypeRad = ({ tiltakstype }: TiltakstypeRadProps) => {
   const { id, tittel, ingress } = tiltakstype;
-  console.log('ingress', ingress);
   return (
     <tr key={id} className="tabell__row">
       <td>

--- a/src/components/tiltakstypeoversikt/listevisning/TiltakstypeRad.tsx
+++ b/src/components/tiltakstypeoversikt/listevisning/TiltakstypeRad.tsx
@@ -9,6 +9,7 @@ interface TiltakstypeRadProps {
 
 const TiltakstypeRad = ({ tiltakstype }: TiltakstypeRadProps) => {
   const { id, tittel, ingress } = tiltakstype;
+  console.log('ingress', ingress);
   return (
     <tr key={id} className="tabell__row">
       <td>
@@ -16,7 +17,7 @@ const TiltakstypeRad = ({ tiltakstype }: TiltakstypeRadProps) => {
           {tittel}
         </Link>
       </td>
-      <td>{ingress}</td>
+      <td className="tabell__row__ingress">{ingress}</td>
     </tr>
   );
 };


### PR DESCRIPTION
Dette er en midlertidig fiks slik at ting ikke ser altfor tullete ut. Har varslet Joachim om at vi burde lage noe annet ut av oversikten enn en tabell